### PR TITLE
fix: encode Authorization header in base64

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -340,7 +340,7 @@ export class Transmission implements TorrentClient {
     };
     if (this.config.username || this.config.password) {
       const str = `${this.config.username ?? ''}:${this.config.password ?? ''}`;
-      headers.Authorization = 'Basic ' + str;
+      headers.Authorization = 'Basic ' + Buffer.from(str).toString('base64');
     }
 
     const url = urlJoin(this.config.baseUrl, this.config.path);


### PR DESCRIPTION
The `Authorization: Basic` header is not encoded in base64, which does not conform to the standard. This PR encodes `Authorization` in base64, effectively fixing username & password based authentication.