### PR TITLE
feat: Switch to using hash as the normalized id

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -45,12 +45,18 @@ export interface FreeSpaceResponse extends DefaultResponse {
 /**
  * "ids", which specifies which torrents to use.
  * All torrents are used if the "ids" argument is omitted.
+ *
  * "ids" should be one of the following:
- * (1) an integer referring to a torrent id
- * (2) a list of torrent id numbers, sha1 hash strings, or both
- * (3) a string, "recently-active", for recently-active torrents
+ * 1. an integer referring to a torrent id
+ * 2. a list of torrent id numbers, sha1 hash strings, or both
+ * 3. a string, "recently-active", for recently-active torrents
  */
 export type TorrentIds = number | 'recently-active' | Array<number | string>;
+
+/**
+ * Allows the user to pass a single hash, this will be converted to an array
+ */
+export type NormalizedTorrentIds = TorrentIds | string;
 
 export interface GetTorrentRepsonse extends DefaultResponse {
   arguments: {

--- a/test/transmission.spec.ts
+++ b/test/transmission.spec.ts
@@ -12,7 +12,7 @@ const baseUrl = 'http://localhost:9091/';
 const torrentName = 'ubuntu-18.04.1-desktop-amd64.iso';
 const torrentFile = path.join(__dirname, '/ubuntu-18.04.1-desktop-amd64.iso.torrent');
 
-async function setupTorrent(transmission: Transmission) {
+async function setupTorrent(transmission: Transmission): Promise<string> {
   const res = await transmission.addTorrent(torrentFile);
   await pWaitFor(
     async () => {
@@ -21,7 +21,7 @@ async function setupTorrent(transmission: Transmission) {
     },
     { timeout: 10000, interval: 200 },
   );
-  return res.arguments['torrent-added'].id;
+  return res.arguments['torrent-added'].hashString;
 }
 
 describe('Transmission', () => {


### PR DESCRIPTION
BREAKING CHANGE: uses the torrent hash as the id. Will automatically convert a single hash to an array of hashes as required by the api.